### PR TITLE
fix: search_entities default "format" value is invalid

### DIFF
--- a/src/queries/wikidata_search_entities.coffee
+++ b/src/queries/wikidata_search_entities.coffee
@@ -11,7 +11,7 @@ module.exports = (search, language, limit, format)->
 
   language or= 'en'
   limit or= '20'
-  format or= '20'
+  format or= 'json'
 
   return buildUrl 'wikidata',
     action: 'wbsearchentities'


### PR DESCRIPTION
The example given in readme doesn't work, this should fix it.

Url generated : https://www.wikidata.org/w/api.php?action=wbsearchentities&search=Ingmar%20Bergman&language=fr&limit=10&format=20

Error returned :
```
"error": {
        "code": "unknown_format",
        "info": "Unrecognized value for parameter 'format': 20",
        "*": "See https://www.wikidata.org/w/api.php for API usage"
    }
```