### PR TITLE
Add support for `keepTypes` on simplify.claims

### DIFF
--- a/docs/simplify_claims.md
+++ b/docs/simplify_claims.md
@@ -16,6 +16,7 @@
 - [Options](#options)
   - [Add prefixes to entities and properties ids](#add-prefixes-to-entities-and-properties-ids)
   - [Keep rich values](#keep-rich-values)
+  - [Keep types](#keep-types)
   - [Keep qualifiers](#keep-qualifiers)
   - [Keep references](#keep-references)
   - [Keep ids](#keep-ids)
@@ -151,6 +152,43 @@ By default, `simplify.claims` returns only the simpliest values, so just a strin
 By setting `keepRichValues=true`,
 - `monolingualtext` values will be objects on the pattern `{ text, language }`
 - `quantity` values will be objects on the pattern `{ amount, unit, upperBound, lowerBound }`
+
+### Keep types
+> `keepTypes`
+
+You can keep the value's types by passing `keepTypes: true` in the options:
+```js
+wdk.simplify.claims(entity.claims, { keepTypes: true })
+wdk.simplify.propertyClaims(entity.claims.P50, { keepTypes: true })
+wdk.simplify.claim(entity.claims.P50[0], { keepTypes: true })
+```
+Results would then look something like
+```json
+{
+  "P1365": [
+    {
+      "value": "Q312881",
+      "type": "wikibase-item"
+    }
+  ]
+}
+```
+
+Here is a list with all the supported types:
+
+ - `"string"`
+ - `"commonsMedia"`
+ - `"url"`
+ - `"external-id"`
+ - `"math"`
+ - `"monolingualtext"`
+ - `"wikibase-item"`
+ - `"wikibase-property"`
+ - `"time"`
+ - `"quantity"`
+ - `"globe-coordinate"`
+ - `"geo-shape"`
+ - `"tabular-data"`
 
 ### Keep qualifiers
 > `keepQualifiers`

--- a/lib/helpers/simplify_claims.js
+++ b/lib/helpers/simplify_claims.js
@@ -60,7 +60,7 @@ const nonNull = obj => obj != null
 // Ex: entity.claims.P369[0]
 const simplifyClaim = function (claim, ...options) {
   options = parseOptions(options)
-  const { keepQualifiers, keepReferences, keepIds, keepHashes } = options
+  const { keepQualifiers, keepReferences, keepIds, keepHashes, keepTypes } = options
   // tries to replace wikidata deep claim object by a simple value
   // e.g. a string, an entity Qid or an epoch time number
   const { mainsnak } = claim
@@ -86,19 +86,33 @@ const simplifyClaim = function (claim, ...options) {
 
   // Qualifiers should not attempt to keep sub-qualifiers or references
   if (isQualifierSnak) {
-    if (keepHashes) return { value, hash: claim.hash }
-    else return value
+    if (!(keepHashes || keepTypes)) return value
+
+    const richValue = { value }
+
+    if (keepHashes) richValue.hash = claim.hash
+    if (keepTypes) richValue.type = datatype
+
+    return richValue
   }
 
-  if (isReferenceSnak) return value
+  if (isReferenceSnak) {
+    if (!keepTypes) return value
+
+    return { type: datatype, value }
+  }
 
   // No need to test keepHashes as it has no effect if neither
   // keepQualifiers or keepReferences is true
-  if (!(keepQualifiers || keepReferences || keepIds)) return value
+  if (!(keepQualifiers || keepReferences || keepIds || keepTypes)) return value
 
   // When keeping qualifiers or references, the value becomes an object
   // instead of a direct value
   const richValue = { value }
+
+  if (keepTypes) {
+    richValue.type = datatype
+  }
 
   // Using a new object so that the original options object isn't modified
   const subSnaksOptions = Object.assign({}, options, { areSubSnaks: true, keepHashes })

--- a/test/simplify_claims.js
+++ b/test/simplify_claims.js
@@ -242,6 +242,14 @@ describe('simplifyClaim', function () {
     })
   })
 
+  describe('keepTypes', function () {
+    it('should return the correct value when called with keepQualifiers=true', function (done) {
+      const simplified = simplifyClaim(Q2112.claims.P190[0], { keepTypes: true })
+      simplified.should.deepEqual({ value: 'Q207614', type: 'wikibase-item' })
+      done()
+    })
+  })
+
   describe('qualifiers', function () {
     it('should return the correct value when called with keepQualifiers=true', function (done) {
       const simplified = simplifyClaim(Q571.claims.P279[0])
@@ -264,6 +272,13 @@ describe('simplifyClaim', function () {
       const simplifiedWithQualifiers = simplifyClaim(Q646148.claims.P39[1], { entityPrefix: 'wd', propertyPrefix: 'wdt', keepQualifiers: true })
       simplifiedWithQualifiers.qualifiers['wdt:P1365'].should.be.an.Array()
       simplifiedWithQualifiers.qualifiers['wdt:P1365'][0].should.equal('wd:Q312881')
+      done()
+    })
+
+    it('should include types in qualifiers claims', function (done) {
+      const simplifiedWithQualifiers = simplifyClaim(Q646148.claims.P39[1], { keepTypes: true, keepQualifiers: true })
+      simplifiedWithQualifiers.qualifiers['P1365'].should.be.an.Array()
+      simplifiedWithQualifiers.qualifiers['P1365'][0].should.deepEqual({ value: 'Q312881', type: 'wikibase-item' })
       done()
     })
   })


### PR DESCRIPTION
I think that providing the value type on rich value claims could be beneficial.

For example:

```js
const simplifiedClaims = wdk.simplify.claims(entity.claims, { keepType: true });
```

```
"P279": [ { "type": "wikibase-entityid", "value": "Q340169" } ]
```