### PR TITLE
Extend entity id checks

### DIFF
--- a/lib/helpers/helpers.js
+++ b/lib/helpers/helpers.js
@@ -1,10 +1,10 @@
 const toDateObject = require('./wikidata_time_to_date_object')
 
 const helpers = {}
-helpers.isNumericId = id => /^[0-9]+$/.test(id)
-helpers.isEntityId = id => /^(Q|P)[0-9]+$/.test(id)
-helpers.isItemId = id => /^Q[0-9]+$/.test(id)
-helpers.isPropertyId = id => /^P[0-9]+$/.test(id)
+helpers.isNumericId = id => /^[1-9][0-9]*$/.test(id)
+helpers.isEntityId = id => /^(Q|P)[1-9][0-9]*$/.test(id)
+helpers.isItemId = id => /^Q[1-9][0-9]*$/.test(id)
+helpers.isPropertyId = id => /^P[1-9][0-9]*$/.test(id)
 helpers.isGuid = guid => /^(Q|P|L)\d+\$[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(guid)
 
 helpers.getNumericId = function (id) {


### PR DESCRIPTION
Numeric values of entity ids never start with `0` so more false positives can be eleminated.