### PR TITLE
Fix more time converter helper edge cases

### DIFF
--- a/lib/helpers/helpers.js
+++ b/lib/helpers/helpers.js
@@ -20,7 +20,12 @@ const bestEffort = fn => value => {
     return fn(value)
   } catch (err) {
     value = value.time || value
-    return value.replace('-00-00', '-01-01')
+
+    const sign = value[0]
+    let [ yearMonthDay, withinDay ] = value.slice(1).split('T')
+    yearMonthDay = yearMonthDay.replace(/-00/g, '-01')
+
+    return `${sign}${yearMonthDay}T${withinDay}`
   }
 }
 

--- a/lib/helpers/wikidata_time_to_date_object.js
+++ b/lib/helpers/wikidata_time_to_date_object.js
@@ -16,22 +16,24 @@ module.exports = function (wikidataTime) {
 }
 
 const fullDateData = function (sign, rest) {
-  return sign === '-' ? negativeDate(rest) : positiveDate(rest)
+  const year = rest.split('-')[0]
+  const needsExpandedYear = sign === '-' || year.length > 4
+
+  return needsExpandedYear ? expandedYearDate(sign, rest, year) : new Date(rest)
 }
 
-const positiveDate = rest => new Date(rest)
-const negativeDate = function (rest) {
-  const year = rest.split('-')[0]
+const expandedYearDate = function (sign, rest, year) {
   var date
-  // Using ISO8601 expanded notation for negative years: adding 2 leading zeros
+  // Using ISO8601 expanded notation for negative years or positive
+  // years with more than 4 digits: adding up to 2 leading zeros
   // when needed. Can't find the documentation again, but testing
   // with `new Date(date)` gives a good clue of the implementation
   if (year.length === 4) {
-    date = `-00${rest}`
+    date = `${sign}00${rest}`
   } else if (year.length === 5) {
-    date = `-0${rest}`
+    date = `${sign}0${rest}`
   } else {
-    date = `-${rest}`
+    date = sign + rest
   }
   return new Date(date)
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -64,18 +64,27 @@ describe('helpers', function () {
       wikidataTimeToISOString('-34000-00-00T00:00:00Z')
       .should.equal('-034000-01-01T00:00:00.000Z')
 
+      wikidataTimeToISOString('+34000-00-00T00:00:00Z')
+      .should.equal('+034000-01-01T00:00:00.000Z')
+
       done()
     })
 
     it('should return a valid time for possible invalid dates', function (done) {
       wikidataTimeToISOString('+1953-00-00T00:00:00Z')
       .should.equal('1953-01-01T00:00:00.000Z')
+
+      wikidataTimeToISOString('+1953-11-00T00:00:00Z')
+      .should.equal('1953-11-01T00:00:00.000Z')
       done()
     })
 
     it('should return a valid time even for possible invalid negative date', function (done) {
       wikidataTimeToISOString('-1953-00-00T00:00:00Z')
       .should.equal('-001953-01-01T00:00:00.000Z')
+
+      wikidataTimeToISOString('-1953-11-00T00:00:00Z')
+      .should.equal('-001953-11-01T00:00:00.000Z')
       done()
     })
 
@@ -83,8 +92,23 @@ describe('helpers', function () {
       wikidataTimeToISOString('-13798000000-00-00T00:00:00Z')
       .should.equal('-13798000000-01-01T00:00:00Z')
 
+      wikidataTimeToISOString('-13798000000-02-00T00:00:00Z')
+      .should.equal('-13798000000-02-01T00:00:00Z')
+
       wikidataTimeToISOString('-13798000000-02-07T15:00:00Z')
       .should.equal('-13798000000-02-07T15:00:00Z')
+      done()
+    })
+
+    it('should return a valid time for dates far in the future', function (done) {
+      wikidataTimeToISOString('+13798000000-00-00T00:00:00Z')
+      .should.equal('+13798000000-01-01T00:00:00Z')
+
+      wikidataTimeToISOString('+13798000000-02-00T00:00:00Z')
+      .should.equal('+13798000000-02-01T00:00:00Z')
+
+      wikidataTimeToISOString('+13798000000-02-07T15:00:00Z')
+      .should.equal('+13798000000-02-07T15:00:00Z')
       done()
     })
 


### PR DESCRIPTION
Follow up to #51: years with more than 6 digits currently have a related bug because they fall back to `bestEffort`, which only handles the case where _both_ month and day are `00`, but not day only. Not that I would expect to see many time values that far in the past/future with month precision, but hey...

Secondly, dates with positive years from 5-6 digits currently fall back to `bestEffort` because they fail parsing, but they should pass. They just need to be padded and signed similar to negative years.

This PR fixes those edge cases, and there are also a couple more tests to cover e8edbdd5b2a00c6ec33c3ffda5179b14d352180b