### PR TITLE
Improve package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "6.0.1",
   "description": "A javascript tool-suite to query Wikidata and simplify its results",
   "main": "lib/index.js",
+  "files": [
+    "dist",
+    "lib"
+  ],
   "directories": {
     "lib": "lib",
     "doc": "docs",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A javascript tool-suite to query Wikidata and simplify its results",
   "main": "lib/index.js",
   "directories": {
-    "test": "tests"
+    "lib": "lib",
+    "doc": "docs",
+    "test": "test"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
In order to have a smaller and cleaner package I added [files](https://docs.npmjs.com/files/package.json#files) to the `package.json`.

Normally the `dist` folder would not be required but as you suggested to use it on old NodeJS versions in the readme I included it.

In order to check what files are in the package use `npm pack`. Scripts for example will not be used so they don't have to be shipped.