### PR TITLE
feat(simplify_claims): timeConverter as function

### DIFF
--- a/docs/simplify_claims.md
+++ b/docs/simplify_claims.md
@@ -400,11 +400,31 @@ wdk.simplify.claims(claims, { keepAll: true, keepTypes: false })
 
 By default, `simplify.claims` functions use [`wikidataTimeToISOString`](general_helpers.md#wikidataTimeToISOString) to parse [Wikidata time values](https://www.mediawiki.org/wiki/Wikibase/DataModel#Dates_and_times).
 
-You can nevertheless request to use a different converter by setting the option `timeConverter`.
+You can nevertheless request to use a different converter by setting the option `timeConverter`:
+
+```js
+wdk.simplify.claims(claims, { timeConverter: 'iso' })
+```
 
 Possible modes:
-
 * `iso`: the default value
 * `epoch`: get the time value as the milliseconds elapsed since 1 January 1970 00:00:00 UTC (as returned by [Javascript `getTime`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime))
 * `simple-day`: returns dates on the format 'yyyy-mm-dd', 'yyyy-mm', 'yyyy' depending on the date precision.
 * `none`: get the raw non-standard Wikidata `time` string (ex: `+1885-00-00T00:00:00Z`)
+
+
+If none of those format fits your needs, you can pass a custom time converter function that will receive the full data object:
+```js
+{
+  time: '+1939-11-08T00:00:00Z',
+  timezone: 0,
+  before: 0,
+  after: 0,
+  precision: 11,
+  calendarmodel: 'http://www.wikidata.org/entity/Q1985727'
+}
+```
+```js
+const timeConverterFn = ({ time, precision }) => `foo/${time}/${precision}/bar`
+wdk.simplify.claims(claims, { timeConverter })
+```

--- a/lib/helpers/parse_claim.js
+++ b/lib/helpers/parse_claim.js
@@ -39,7 +39,11 @@ const coordinate = datavalue => {
 }
 
 const time = (datavalue, options) => {
-  return getTimeConverter(options.timeConverter)(datavalue.value)
+  if (typeof options.timeConverter === 'function') {
+    return options.timeConverter(datavalue.value)
+  } else {
+    return getTimeConverter(options.timeConverter)(datavalue.value)
+  }
 }
 
 const getTimeConverter = (key = 'iso') => timeConverters[key]

--- a/lib/helpers/parse_claim.js
+++ b/lib/helpers/parse_claim.js
@@ -46,7 +46,11 @@ const time = (datavalue, options) => {
   }
 }
 
-const getTimeConverter = (key = 'iso') => timeConverters[key]
+const getTimeConverter = (key = 'iso') => {
+  const converter = timeConverters[key]
+  if (!converter) throw new Error(`invalid converter key: ${JSON.stringify(key).substring(0, 100)}`)
+  return converter
+}
 
 // Each time converter should be able to accept 2 keys of arguments:
 // - either datavalue.value objects (prefered as it gives access to the precision)

--- a/test/simplify_claims.js
+++ b/test/simplify_claims.js
@@ -376,6 +376,25 @@ describe('simplifyClaim', function () {
       simplifiedWithQualifiers.qualifiers['P1365'][0].should.deepEqual({ value: 'Q312881', type: 'wikibase-item' })
       done()
     })
+
+    it('should respect timeConverter for qualifiers claims', function (done) {
+      let simplifiedWithQualifiers = simplifyClaim(Q571.claims.P1709[0], { keepQualifiers: true, timeConverter: 'iso' })
+      simplifiedWithQualifiers.qualifiers.P813.should.be.an.Array()
+      simplifiedWithQualifiers.qualifiers.P813[0].should.equal('2015-06-11T00:00:00.000Z')
+      simplifiedWithQualifiers = simplifyClaim(Q571.claims.P1709[0], { keepQualifiers: true, timeConverter: 'epoch' })
+      simplifiedWithQualifiers.qualifiers.P813.should.be.an.Array()
+      simplifiedWithQualifiers.qualifiers.P813[0].should.equal(1433980800000)
+      simplifiedWithQualifiers = simplifyClaim(Q571.claims.P1709[0], { keepQualifiers: true, timeConverter: 'simple-day' })
+      simplifiedWithQualifiers.qualifiers.P813.should.be.an.Array()
+      simplifiedWithQualifiers.qualifiers.P813[0].should.equal('2015-06-11')
+      simplifiedWithQualifiers = simplifyClaim(Q571.claims.P1709[0], { keepQualifiers: true, timeConverter: 'none' })
+      simplifiedWithQualifiers.qualifiers.P813.should.be.an.Array()
+      simplifiedWithQualifiers.qualifiers.P813[0].should.equal('+2015-06-11T00:00:00Z')
+      simplifiedWithQualifiers = simplifyClaim(Q571.claims.P1709[0], { keepQualifiers: true, timeConverter: v => `foo/${v.time}/${v.precision}/bar` })
+      simplifiedWithQualifiers.qualifiers.P813.should.be.an.Array()
+      simplifiedWithQualifiers.qualifiers.P813[0].should.equal('foo/+2015-06-11T00:00:00Z/11/bar')
+      done()
+    })
   })
 
   describe('references', function () {

--- a/test/simplify_claims.js
+++ b/test/simplify_claims.js
@@ -9,7 +9,6 @@ const Q2112 = require('./data/Q2112.json')
 const Q217447 = require('./data/Q217447.json')
 const Q271094 = require('./data/Q271094.json')
 const Q4115189 = require('./data/Q4115189.json')
-const Q970917 = require('./data/Q970917.json')
 const Q1 = require('./data/Q1.json')
 const oldClaimFormat = require('./data/old_claim_format.json')
 const lexemeClaim = require('./data/lexeme_claim.json')
@@ -487,31 +486,27 @@ describe('simplifyClaim', function () {
 
   describe('time converter', function () {
     it('should use a custom time converter when one is set', function (done) {
-      const timeClaim = (entity, timeConverter) => {
-        return simplifyClaim(entity.claims.P569[0], { timeConverter })
-      }
-      timeClaim(Q646148).should.equal('1939-11-08T00:00:00.000Z')
-      timeClaim(Q646148, 'iso').should.equal('1939-11-08T00:00:00.000Z')
-      timeClaim(Q646148, 'epoch').should.equal(-951436800000)
-      timeClaim(Q646148, 'simple-day').should.equal('1939-11-08')
-      timeClaim(Q646148, 'none').should.equal('+1939-11-08T00:00:00Z')
-      // New date format: missing precision units use 01 instead of 00
-      timeClaim(Q970917).should.equal('1869-11-01T00:00:00.000Z')
-      timeClaim(Q970917, 'iso').should.equal('1869-11-01T00:00:00.000Z')
-      timeClaim(Q970917, 'epoch').should.equal(-3160944000000)
-      timeClaim(Q970917, 'simple-day').should.equal('1869-11')
-      timeClaim(Q970917, 'none').should.equal('+1869-11-01T00:00:00Z')
+      const claim = Q646148.claims.P569[0]
+      const simplifyTimeClaim = timeConverter => simplifyClaim(claim, { timeConverter })
+      simplifyTimeClaim().should.equal('1939-11-08T00:00:00.000Z')
+      simplifyTimeClaim('iso').should.equal('1939-11-08T00:00:00.000Z')
+      simplifyTimeClaim('epoch').should.equal(-951436800000)
+      simplifyTimeClaim('simple-day').should.equal('1939-11-08')
+      simplifyTimeClaim('none').should.equal('+1939-11-08T00:00:00Z')
+      const timeConverterFn = ({ time, precision }) => `foo/${time}/${precision}/bar`
+      simplifyTimeClaim(timeConverterFn).should.equal('foo/+1939-11-08T00:00:00Z/11/bar')
       done()
     })
 
     it('should be able to parse long dates', function (done) {
-      const timeClaim = timeConverter => {
-        return simplifyClaim(Q1.claims.P580[0], { timeConverter })
-      }
-      timeClaim().should.equal('-13798000000-01-01T00:00:00Z')
-      timeClaim('none').should.equal('-13798000000-00-00T00:00:00Z')
-      timeClaim('iso').should.equal('-13798000000-01-01T00:00:00Z')
-      timeClaim('simple-day').should.equal('-13798000000')
+      const claim = Q1.claims.P580[0]
+      const simplifyTimeClaim = timeConverter => simplifyClaim(claim, { timeConverter })
+      simplifyTimeClaim().should.equal('-13798000000-01-01T00:00:00Z')
+      simplifyTimeClaim('none').should.equal('-13798000000-00-00T00:00:00Z')
+      simplifyTimeClaim('iso').should.equal('-13798000000-01-01T00:00:00Z')
+      simplifyTimeClaim('simple-day').should.equal('-13798000000')
+      const timeConverterFn = ({ time, precision }) => `foo/${time}/${precision}/bar`
+      simplifyTimeClaim(timeConverterFn).should.equal('foo/-13798000000-00-00T00:00:00Z/3/bar')
       // Can't be supported due to JS large numbers limitations;
       // 13798000000*365.25*24*60*60*1000 is too big
       // timeClaim('epoch').should.equal('-13798000000-00-00T00:00:00Z')

--- a/test/simplify_qualifiers.js
+++ b/test/simplify_qualifiers.js
@@ -1,5 +1,6 @@
 const should = require('should')
 const { simplifyQualifier, simplifyPropertyQualifiers, simplifyQualifiers } = require('../lib/helpers/simplify_claims')
+const Q571 = require('./data/Q571.json')
 const Q2112 = require('./data/Q2112.json')
 const Q19180293 = require('./data/Q19180293.json')
 
@@ -31,6 +32,20 @@ describe('simplifyQualifier', function () {
     it('should accept null as a possible value', function (done) {
       const noValueQualifier = Q19180293.claims.P1433[0].qualifiers.P1100[0]
       should(simplifyQualifier(noValueQualifier, { novalueValue: null }) === null).be.true()
+      done()
+    })
+  })
+
+  describe('time', function () {
+    it('should respect timeConverter for qualifiers claims', function (done) {
+      const qualifier = Q571.claims.P1709[0].qualifiers.P813[0]
+      const timeClaim = timeConverter => simplifyQualifier(qualifier, { timeConverter })
+      timeClaim('iso').should.equal('2015-06-11T00:00:00.000Z')
+      timeClaim('epoch').should.equal(1433980800000)
+      timeClaim('simple-day').should.equal('2015-06-11')
+      timeClaim('none').should.equal('+2015-06-11T00:00:00Z')
+      const timeConverterFn = ({ time, precision }) => `foo/${time}/${precision}/bar`
+      timeClaim(timeConverterFn).should.equal('foo/+2015-06-11T00:00:00Z/11/bar')
       done()
     })
   })


### PR DESCRIPTION
This allows to pass a custom function for the timeConverter option.