### PR TITLE
add `formatversion` to `WbGetEntities`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export * from './types/sitelinks.js'
 export * from './types/snakvalue.js'
 export * from './types/sparql.js'
 export * from './types/terms.js'
+export * from './types/wbgetentities.js'
 
 // In case of missing types on Wbk, check ./wikibase-sdk.ts exports
 

--- a/src/types/wbgetentities.ts
+++ b/src/types/wbgetentities.ts
@@ -10,4 +10,5 @@ export interface WbGetEntities {
   languages?: string
   props?: string
   redirects?: 'yes' | 'no' // Default: yes
+  formatversion?: '1' | '2';
 }

--- a/src/types/wbgetentities.ts
+++ b/src/types/wbgetentities.ts
@@ -10,5 +10,5 @@ export interface WbGetEntities {
   languages?: string
   props?: string
   redirects?: 'yes' | 'no' // Default: yes
-  formatversion?: '1' | '2';
+  formatversion?: '1' | '2' // Undocumented attribute, see https://github.com/maxlath/wikibase-sdk/pull/136
 }


### PR DESCRIPTION
`formatversion` is undocumented[<sup>[1]</sup>](https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities) but it does exist[<sup>[2]</sup>](https://phabricator.wikimedia.org/T121334). Also exported this interface, for anyone that's using this library purely for its type-defintions 